### PR TITLE
Fix : The type of TimingPointDensityFactor is modified to float

### DIFF
--- a/src/arcfutil/aff/note/notegroup.py
+++ b/src/arcfutil/aff/note/notegroup.py
@@ -11,15 +11,15 @@ from ..sorter import sort
 
 
 class AffList(NoteGroup):
-    def __init__(self, *notes, offset: int = 0, desinty: int = 1):
+    def __init__(self, *notes, offset: int = 0, desnity: float = 1):
         super(AffList, self).__init__(*notes)
         self.offset: int = offset
-        self.desnity: int = desinty
+        self.desnity: float = desnity
 
     def __str__(self):
         return ''.join([
             'AudioOffset:{:d}\n'.format(int(self.offset)),
-            'TimingPointDensityFactor:{:d}\n'.format(int(self.desnity)) if self.desnity != 1 else '',
+            'TimingPointDensityFactor:{:.3f}\n'.format(float(self.desnity)) if self.desnity != 1 else '',
             '-\n'
         ]) + super().__str__()
 

--- a/src/arcfutil/aff/parser.py
+++ b/src/arcfutil/aff/parser.py
@@ -153,7 +153,7 @@ def load(affstr: str):
                 notelist.offset = int(stripedlinestr[stripedlinestr.index(':') + 1:])
                 continue
             elif stripedlinestr.startswith('TimingPointDensityFactor'):
-                notelist.desnity = int(stripedlinestr[stripedlinestr.index(':') + 1:])
+                notelist.desnity = float(stripedlinestr[stripedlinestr.index(':') + 1:])
                 continue
             elif stripedlinestr == '};':
                 notelist.append(tempstruct)


### PR DESCRIPTION
I tried to load 2.aff of `hallomirrors`, however I only got `ValueError: invalid literal for int() with base 10: '1.001'`.

I checked the code and found when operating TimingPointDensityFactor, it is always treated as an integer.

So I modified it to float, and round it to three decimal places when call str(AffList).