### PR TITLE
Fix bugs about align()

### DIFF
--- a/src/arcfutil/aff/note/arc.py
+++ b/src/arcfutil/aff/note/arc.py
@@ -190,6 +190,11 @@ class Arc(Hold):
         
     def align(self, bpm: float, error: int = 3, lcm = 96):
         super(Arc, self).align(bpm, error, lcm)
+        # 防止单天键出 bug
+        if self.time == self.totime:
+            if self.skynote:
+                self.totime += 1
+        
         if self.skynote:
             for each in enumerate(self.skynote):
                 self.skynote[each[0]] = time_align(self.skynote[each[0]], bpm, error, lcm)

--- a/src/arcfutil/aff/note/common_note.py
+++ b/src/arcfutil/aff/note/common_note.py
@@ -6,13 +6,16 @@
 
 from copy import deepcopy
 from typing import Iterable
-
+import math
 
 def time_align(time: int, bpm: float, error: int = 3, lcm = 96):
     fpb = 60000 * 4 / bpm / lcm
     alignedTime = 0
-    atime1 = round(time//fpb*fpb) #向下取grid时间戳
-    atime2 = round((time//fpb+1)*fpb) #向上取grid时间戳
+    # atime1 = round(time//fpb*fpb) #向下取grid时间戳
+    # atime2 = round((time//fpb+1)*fpb) #向上取grid时间戳
+    # 因为 sb616 在游戏本体里用的好像是向下取整，所以这里用 floor 好了
+    atime1 = math.floor(time//fpb*fpb) #向下取grid时间戳
+    atime2 = math.floor((time//fpb+1)*fpb) #向上取grid时间戳
     abs1 = abs(time - atime1) #atime1与time的距离
     abs2 = abs(time - atime2)
     ok1 = (abs1 <= error) #abs1是否在容差内

--- a/src/arcfutil/aff/note/hold.py
+++ b/src/arcfutil/aff/note/hold.py
@@ -75,6 +75,6 @@ class Hold(Tap):
     def align(self, bpm: float, error: int = 3, lcm = 96):
         super(Hold, self).align(bpm, error, lcm)
         self.totime = time_align(self.totime, bpm, error, lcm)
-        if self.time == self.totime:
-            self.totime += 1
+        # if self.time == self.totime:
+        #    self.totime += 1
         return self


### PR DESCRIPTION
Fix: align()导致0长黑线等谱面错误无法被检测出的 bug
Fix: align()使用round()导致其与616的物量计算机制不符从而导致谱面物量bug，现已替换为math.floor()